### PR TITLE
Sort key and db request batching

### DIFF
--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -10,14 +10,15 @@ export class GbgFarligtAvfallStack extends Stack {
     this.lambdaCode = lambda.Code.fromCfnParameters();
 
     const gfaEvents = new dynamodb.Table(this, 'gfa-events', {
-      partitionKey: { name: 'event-date', type: dynamodb.AttributeType.STRING }
+      partitionKey: { name: 'event-date', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'district-and-street', type: dynamodb.AttributeType.STRING }
     });
 
     const gfaPoller = new lambda.Function(this, 'gfa-poller', {
       code: this.lambdaCode,
       handler: 'doesnt.matter',
       runtime: lambda.Runtime.PROVIDED,
-      timeout: Duration.seconds(3),
+      timeout: Duration.seconds(10),
       environment: {
         EVENTS_TABLE: gfaEvents.tableName,
       }

--- a/gfa-poller/src/pickup_event.rs
+++ b/gfa-poller/src/pickup_event.rs
@@ -56,6 +56,10 @@ impl PickUpEvent {
     pub fn end_time(self: &Self) -> String {
         self.time_end.to_rfc3339()
     }
+
+    pub fn district_and_street(self: &Self) -> String {
+        format!("{}/{}", self.district, self.street)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
 - Use a sort key to separate events
 - Chunk db calls to 25 WriteRequests per BatchWriteRequest (no more is allowed)