### PR TITLE
Change format of the 'location id' to something a bit less prone to errors

### DIFF
--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -12,7 +12,7 @@ export class GbgFarligtAvfallStack extends Stack {
 
     const gfaEvents = new dynamodb.Table(this, 'gfa-events', {
       partitionKey: { name: 'event-date', type: dynamodb.AttributeType.STRING },
-      sortKey: { name: 'district-and-street', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'location-id', type: dynamodb.AttributeType.STRING },
       billingMode: BillingMode.PAY_PER_REQUEST,
     });
 

--- a/gfa-poller/src/events_repo.rs
+++ b/gfa-poller/src/events_repo.rs
@@ -23,8 +23,8 @@ pub async fn store(table: String, region: Region, events: Vec::<PickUpEvent>) ->
                 s: Some(event.date()),
                 ..Default::default()
             });
-            attributes.insert("district-and-street".to_string(), AttributeValue{
-                s: Some(event.district_and_street()),
+            attributes.insert("location-id".to_string(), AttributeValue{
+                s: Some(event.location_id()),
                 ..Default::default()
             });
             attributes.insert("district".to_string(), AttributeValue{

--- a/gfa-poller/src/pickup_event.rs
+++ b/gfa-poller/src/pickup_event.rs
@@ -57,8 +57,11 @@ impl PickUpEvent {
         self.time_end.to_rfc3339()
     }
 
-    pub fn district_and_street(self: &Self) -> String {
-        format!("{}/{}", self.district, self.street)
+    pub fn location_id(self: &Self) -> String {
+        format!("{}_{}",
+            self.district.to_lowercase().trim().replace(" ", ""),
+            self.street.to_lowercase().trim().replace(" ", "")
+        )
     }
 }
 
@@ -82,5 +85,11 @@ mod tests {
     fn should_get_date() {
         let event = PickUpEvent::new("Sunnerviksgatan 38".to_string(), "Västra Hisingen".to_string(), Some("jättestensskolan".to_string()), "2020-09-23T18:00:00+02:00".to_string(), "2020-09-23T18:45:00+02:00".to_string()).unwrap();
         assert_eq!("2020-09-23".to_string(), event.date());
+    }
+
+    #[test]
+    fn should_generate_location_id() {
+        let event = PickUpEvent::new("  Doktor Fries torg, Doktor Bondesons Gata ".to_string(), "Centrum".to_string(), Some("jättestensskolan".to_string()), "2020-09-23T18:00:00+02:00".to_string(), "2020-09-23T18:45:00+02:00".to_string()).unwrap();
+        assert_eq!("centrum_doktorfriestorg,doktorbondesonsgata", event.location_id());
     }
 }


### PR DESCRIPTION
E.g. if goteborg.se lists same location but with some extra whitespace, this could otherwise have been treated as two different locations
