### PR TITLE
Improve input address to geocoding API

### DIFF
--- a/gfa-backend/src/preprocess-stops/gen_address.rs
+++ b/gfa-backend/src/preprocess-stops/gen_address.rs
@@ -1,0 +1,48 @@
+use lazy_static::lazy_static;
+use regex::{Regex};
+
+pub fn generate_address(street: &String, district: &String) -> String {
+    lazy_static! {
+        static ref MULTIPLE_STREETS: Regex = Regex::new(r"^(.+)/(.+)$").unwrap();
+        static ref WITH_STREET_AS_SECONDARY: Regex = Regex::new(r"^(.+), (.+)$").unwrap();
+    }
+    match MULTIPLE_STREETS.captures(street) {
+        Some(result) => {
+            let first_street = result.get(1).unwrap().as_str();
+            return format!("{},{},Göteborg", first_street, district);
+        },
+        None => {}
+    };
+    match WITH_STREET_AS_SECONDARY.captures(street) {
+        Some(result) => {
+            let street = result.get(2).unwrap().as_str();
+            return format!("{},{},Göteborg", street, district);
+        },
+        None => {}
+    };
+    return format!("{},{},Göteborg", street, district);
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_split_multiple_streets() {
+        let address = generate_address(&"Kristinelundsgatan/Chalmersgatan".to_string(), &"Centrum".to_string());
+        assert_eq!("Kristinelundsgatan,Centrum,Göteborg".to_string(), address);
+    }
+
+    #[test]
+    fn should_get_street_where_street_is_secondary() {
+        let address = generate_address(&"Kaserntorget, Kungsgatan 22".to_string(), &"Centrum".to_string());
+        assert_eq!("Kungsgatan 22,Centrum,Göteborg".to_string(), address);
+    }
+
+    #[test]
+    fn should_not_modify_good_addresses() {
+        let address = generate_address(&"Framnäsgatan 31A".to_string(), &"Centrum".to_string());
+        assert_eq!("Framnäsgatan 31A,Centrum,Göteborg".to_string(), address);
+    }
+}

--- a/gfa-backend/src/preprocess-stops/main.rs
+++ b/gfa-backend/src/preprocess-stops/main.rs
@@ -9,6 +9,7 @@ use geocoder::GeoCoder;
 use mapquest_geocoder::MapQuestGeoCoder;
 
 mod stop_parser;
+mod gen_address;
 mod geocoder;
 mod mapquest_geocoder;
 
@@ -30,7 +31,7 @@ async fn handle_request(event: Value, _: Context) -> Result<Value, Error> {
     let unique_stops: Vec<PickUpStop> = stop_parser::parse_unique_stops(pickup_events); 
     let mut id_by_address: HashMap<String, String> = HashMap::new();
     for stop in unique_stops.iter() {
-        id_by_address.insert(format!("{},{}", stop.street.clone(), stop.district.clone()), stop.location_id.clone());
+        id_by_address.insert(gen_address::generate_address(&stop.street, &stop.district), stop.location_id.clone());
     }
     let coordinatesMap = MapQuestGeoCoder::forward_geocode("2FSWyWz0ouHBnucVBWA80zsPb6K5wfwc".to_string(), id_by_address)?;
     let mut stops_with_coordinates: Vec<PickUpStop> = Vec::new();


### PR DESCRIPTION
First, only send one single street name. Second, send street name in stead of other places, such as 'Frölunda Torg'
