### PR TITLE
Try static path

### DIFF
--- a/gfa-backend/src/scraper/page_fetcher.rs
+++ b/gfa-backend/src/scraper/page_fetcher.rs
@@ -88,7 +88,6 @@ fn find_paging_path(page: &Vec<u8>) -> Result<String, PageFetcherError> {
             message: format!("Could not parse page")
         })
     };
-
     let node = match doc.find(predicate::Class("c-pagination__link")).into_selection().first() {
         Some(node) => node,
         None => return Err(PageFetcherError{


### PR DESCRIPTION
It seems like goteborg.se use different paths every now and then.
Previously I read the path from a link on the page, and then use that to calculate each page to retrieve.
However, it seems like that same hyperlink now only contain a partial path, and I have a bit trouble finding the complete one.

However, I just tried to use an old path from a few weeks back and it seems to work fine.
Therefore, let's try a static one and see for how long it works.
