### PR TITLE
Output all cfn templates from CDK build step

### DIFF
--- a/gfa-iac/lib/gfa-pipeline-stack.ts
+++ b/gfa-iac/lib/gfa-pipeline-stack.ts
@@ -99,7 +99,7 @@ export class GbgFarligtAvfallPipelineStack extends Stack {
         artifacts: {
           'base-directory': 'gfa-iac/dist',
           files: [
-            'GbgFarligtAvfallStack.template.json',
+            '**/*',
           ],
         },
       }),


### PR DESCRIPTION
I think this is required now, since I have a nested stack template too
