### PR TITLE
Add response models

### DIFF
--- a/gfa-iac/lib/gfa-api-stack.ts
+++ b/gfa-iac/lib/gfa-api-stack.ts
@@ -1,7 +1,7 @@
 import { NestedStack, NestedStackProps } from '@aws-cdk/aws-cloudformation';
 import { IBucket } from '@aws-cdk/aws-s3';
 import { Construct } from '@aws-cdk/core';
-import { Cors, LambdaIntegration, LambdaRestApi, PassthroughBehavior, RestApi } from '@aws-cdk/aws-apigateway';
+import { Cors, LambdaIntegration, LambdaRestApi, PassthroughBehavior, RestApi, JsonSchemaType, JsonSchemaVersion } from '@aws-cdk/aws-apigateway';
 import { functionCreator } from './function-creator';
 
 interface ApiStackProps extends NestedStackProps {
@@ -68,5 +68,32 @@ export class ApiStack extends NestedStack {
                 },
             ],
         }));
+        const responseModel = this.api.addModel('ResponseModel', {
+            contentType: 'application/json',
+            modelName: 'ResponseModel',
+            schema: {
+                schema: JsonSchemaVersion.DRAFT4,
+                title: 'stopsResponse',
+                type: JsonSchemaType.OBJECT,
+                properties: {
+                    state: { type: JsonSchemaType.STRING },
+                    stops: { type: JsonSchemaType.ARRAY }
+                }
+            }
+        });
+
+        const errorResponseModel = this.api.addModel('ErrorResponseModel', {
+            contentType: 'application/json',
+            modelName: 'ErrorResponseModel',
+            schema: {
+                schema: JsonSchemaVersion.DRAFT4,
+                title: 'errorResponse',
+                type: JsonSchemaType.OBJECT,
+                properties: {
+                    state: { type: JsonSchemaType.STRING },
+                    message: { type: JsonSchemaType.STRING }
+                }
+            }
+        });
     }
 }

--- a/gfa-iac/lib/gfa-api-stack.ts
+++ b/gfa-iac/lib/gfa-api-stack.ts
@@ -99,6 +99,7 @@ export class ApiStack extends NestedStack {
                 {
                     statusCode: '200',
                     responseParameters: {
+                        'method.response.header.Content-Type': true,
                         'method.response.header.Access-Control-Allow-Origin': true,
                         'method.response.header.Access-Control-Allow-Methods': true,
                         'method.response.header.Access-Control-Allow-Headers': true,
@@ -109,6 +110,7 @@ export class ApiStack extends NestedStack {
                 }, {
                     statusCode: '400',
                     responseParameters: {
+                        'method.response.header.Content-Type': true,
                         'method.response.header.Access-Control-Allow-Origin': true,
                         'method.response.header.Access-Control-Allow-Methods': true,
                         'method.response.header.Access-Control-Allow-Headers': true,

--- a/gfa-iac/lib/gfa-api-stack.ts
+++ b/gfa-iac/lib/gfa-api-stack.ts
@@ -35,6 +35,33 @@ export class ApiStack extends NestedStack {
                 allowHeaders: ['Content-Type', 'Accept'],
             },
         });
+
+        const responseModel = this.api.addModel('ResponseModel', {
+            contentType: 'application/json',
+            schema: {
+                schema: JsonSchemaVersion.DRAFT4,
+                title: 'stopsResponse',
+                type: JsonSchemaType.OBJECT,
+                properties: {
+                    state: { type: JsonSchemaType.STRING },
+                    stops: { type: JsonSchemaType.ARRAY }
+                }
+            }
+        });
+
+        const errorResponseModel = this.api.addModel('ErrorResponseModel', {
+            contentType: 'application/json',
+            schema: {
+                schema: JsonSchemaVersion.DRAFT4,
+                title: 'errorResponse',
+                type: JsonSchemaType.OBJECT,
+                properties: {
+                    state: { type: JsonSchemaType.STRING },
+                    message: { type: JsonSchemaType.STRING }
+                }
+            }
+        });
+
         const resource = this.api.root.addResource('stops');
         resource.addMethod('GET', new LambdaIntegration(getStops, {
             proxy: false,
@@ -67,33 +94,30 @@ export class ApiStack extends NestedStack {
                     },
                 },
             ],
-        }));
-        const responseModel = this.api.addModel('ResponseModel', {
-            contentType: 'application/json',
-            modelName: 'ResponseModel',
-            schema: {
-                schema: JsonSchemaVersion.DRAFT4,
-                title: 'stopsResponse',
-                type: JsonSchemaType.OBJECT,
-                properties: {
-                    state: { type: JsonSchemaType.STRING },
-                    stops: { type: JsonSchemaType.ARRAY }
-                }
-            }
-        });
-
-        const errorResponseModel = this.api.addModel('ErrorResponseModel', {
-            contentType: 'application/json',
-            modelName: 'ErrorResponseModel',
-            schema: {
-                schema: JsonSchemaVersion.DRAFT4,
-                title: 'errorResponse',
-                type: JsonSchemaType.OBJECT,
-                properties: {
-                    state: { type: JsonSchemaType.STRING },
-                    message: { type: JsonSchemaType.STRING }
-                }
-            }
+        }), {
+            methodResponses: [
+                {
+                    statusCode: '200',
+                    responseParameters: {
+                        'method.response.header.Access-Control-Allow-Origin': true,
+                        'method.response.header.Access-Control-Allow-Methods': true,
+                        'method.response.header.Access-Control-Allow-Headers': true,
+                    },
+                    responseModels: {
+                        'application/json': responseModel,
+                    },
+                }, {
+                    statusCode: '400',
+                    responseParameters: {
+                        'method.response.header.Access-Control-Allow-Origin': true,
+                        'method.response.header.Access-Control-Allow-Methods': true,
+                        'method.response.header.Access-Control-Allow-Headers': true,
+                    },
+                    responseModels: {
+                        'application/json': errorResponseModel,
+                    },
+                },
+            ],
         });
     }
 }


### PR DESCRIPTION
Deploy currently fail with error `Invalid mapping expression specified: Validation Result: warnings : [], errors : [No method response exists for method.] (Service: AmazonApiGateway; Status Code: 400; Error Code: BadRequestException; Request ID: 22ad7930-932b-4904-be7b-39d5b8afc2d4; Proxy: null)`. Let's try to add response models and see if that fixes it.