### PR TITLE
Change format for cloudfront error response path

### DIFF
--- a/gfa-iac/lib/gfa-web-stack.ts
+++ b/gfa-iac/lib/gfa-web-stack.ts
@@ -36,9 +36,16 @@ export class WebStack extends NestedStack {
             defaultRootObject: 'index.html',
             errorConfigurations: [
                 {
+                    errorCode: 403,
+                    responseCode: 200,
+                    responsePagePath: '/index.html',
+                    errorCachingMinTtl: 86400
+                },
+                {
                     errorCode: 404,
                     responseCode: 200,
-                    responsePagePath: 'index.html',
+                    responsePagePath: '/index.html',
+                    errorCachingMinTtl: 86400
                 }
             ] 
         });


### PR DESCRIPTION
Try with slash before index.html, also set ttl and handle both 403 and 404.

Since last deploy failed and I found some example where slash is used: https://hackernoon.com/hosting-static-react-websites-on-aws-s3-cloudfront-with-ssl-924e5c134455