### PR TITLE
Don't add context variables via args property

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,7 @@ jobs:
         uses: youyo/aws-cdk-github-actions@v1
         with:
           working_dir: 'gfa-iac'
-          cdk_subcommand: "deploy"
-          args: "-c artifactsBucketName=${{ secrets.S3_ARTIFACT_BUCKET }} -c version=${{ steps.pull_request.outputs.number }} -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }} -c apiDomainName=${{ secrets.API_DOMAIN_NAME }}"
+          cdk_subcommand: "deploy -c artifactsBucketName=${{ secrets.S3_ARTIFACT_BUCKET }} -c version=${{ steps.pull_request.outputs.number }} -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }} -c apiDomainName=${{ secrets.API_DOMAIN_NAME }}"
           actions_comment: false
 
   deploy-frontend:


### PR DESCRIPTION
Add context variables to deploy command instead of using args property.
Prevous attempt showed that no context variables where included when using args property
