### PR TITLE
Use underscore instead of dash in dynamodb key names

### DIFF
--- a/gfa-backend/src/common/events_repo.rs
+++ b/gfa-backend/src/common/events_repo.rs
@@ -32,7 +32,7 @@ pub async fn get_by_date(table: String, region: Region, date: String) -> Result<
         .query(QueryInput{
             table_name: table,
             expression_attribute_values: Some(attribute_values),
-            key_condition_expression: Some("event-date = :date".to_string()),
+            key_condition_expression: Some("event_date = :date".to_string()),
             ..Default::default()
         })
         .await?
@@ -60,11 +60,11 @@ pub async fn store(table: String, region: Region, events: Vec::<PickUpEvent>) ->
     let write_requests: Vec<WriteRequest> = events.into_iter()
         .map(|event| {
             let mut attributes: HashMap<String, AttributeValue> = HashMap::new(); 
-            attributes.insert("event-date".to_string(), AttributeValue{
+            attributes.insert("event_date".to_string(), AttributeValue{
                 s: Some(event.date),
                 ..Default::default()
             });
-            attributes.insert("location-id".to_string(), AttributeValue{
+            attributes.insert("location_id".to_string(), AttributeValue{
                 s: Some(event.location_id),
                 ..Default::default()
             });

--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -21,8 +21,8 @@ export class GbgFarligtAvfallStack extends Stack {
     const artifactsBucket = Bucket.fromBucketName(this, 'artifactsBucket', props.artifactsBucketName);
 
     const eventsDb = new Table(this, 'gfa-events-db', {
-      partitionKey: { name: 'event-date', type: AttributeType.STRING },
-      sortKey: { name: 'location-id', type: AttributeType.STRING },
+      partitionKey: { name: 'event_date', type: AttributeType.STRING },
+      sortKey: { name: 'location_id', type: AttributeType.STRING },
       billingMode: BillingMode.PAY_PER_REQUEST,
     });
 


### PR DESCRIPTION
Dash is not allowed, but I first noticed it when making a query towards the table. I got error: ValidationException: Invalid KeyConditionExpression: Syntax error; token: "-"
