### PR TITLE
Set FilterPolicy in sns subscribe

### DIFF
--- a/gfa-backend/src/subscribe/subscribe.rs
+++ b/gfa-backend/src/subscribe/subscribe.rs
@@ -7,7 +7,7 @@ pub async fn subscribe(subscription: &Subscription, topic_arn: String, region: R
     let client = SnsClient::new(region);
 
     let mut message_attributes: HashMap<String, String> = HashMap::new();
-    message_attributes.insert("location_id".to_string(), subscription.location_id.clone());
+    message_attributes.insert("FilterPolicy".to_string(), format!("{{\"location_id\": [\"{}\"]}}", subscription.location_id));
     let input = SubscribeInput{
         protocol: "email".to_string(),
         endpoint: Some(subscription.email.clone()),


### PR DESCRIPTION
I think it need to be specified in this way, that the attribute is actually a FilterPolicy (since there are other policies, such as DeliveryPolicy, etc)
And, currently the subscribe lambda fails with: 'Invalid parameter: Attributes Reason: Unknown attribute location_id'
