### PR TITLE
Stop passing around context variables

### DIFF
--- a/gfa-iac/bin/gfa-main.ts
+++ b/gfa-iac/bin/gfa-main.ts
@@ -3,13 +3,4 @@ import { App } from '@aws-cdk/core';
 import { GbgFarligtAvfallStack } from '../lib/gfa-stack';
 
 const app = new App();
-
-const hostedZoneId = app.node.tryGetContext('hostedZoneId');
-const domainName = app.node.tryGetContext('domainName');
-const adminEmail = app.node.tryGetContext('adminEmail');
-
-const gfaStack = new GbgFarligtAvfallStack(app, 'GbgFarligtAvfallStack', {
-  hostedZoneId,
-  domainName,
-  adminEmail
-});
+const gfaStack = new GbgFarligtAvfallStack(app, 'GbgFarligtAvfallStack');

--- a/gfa-iac/lib/gfa-api-stack.ts
+++ b/gfa-iac/lib/gfa-api-stack.ts
@@ -13,8 +13,6 @@ export interface LambdaEndpoint {
     methods: string[],
 }
 interface ApiStackProps extends NestedStackProps {
-    hostedZoneId?: string,
-    domainName?: string,
     lambdaEndpoints: LambdaEndpoint[],
 }
 
@@ -44,11 +42,15 @@ export class ApiStack extends NestedStack {
             })
         })
 
-        if (props.hostedZoneId && props.domainName) {
-            const apiDomainName = `gfa-api.${props.domainName}`;
+
+        const hostedZoneId = scope.node.tryGetContext('hostedZoneId');
+        const domainName = scope.node.tryGetContext('domainName');
+
+        if (hostedZoneId && domainName) {
+            const apiDomainName = `gfa-api.${domainName}`;
             const hostedZone = HostedZone.fromHostedZoneAttributes(this, 'e-hostedzone', {
-                hostedZoneId: props.hostedZoneId,
-                zoneName: props.domainName,
+                hostedZoneId: hostedZoneId,
+                zoneName: domainName,
             });
             const apiCert = new Certificate(this, 'gfa-api-certificate', {
                 domainName: apiDomainName,


### PR DESCRIPTION
Obtain the values where it's needed instead
