### PR TITLE
Custom resource for Sendgrid domain authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           cdk_subcommand: >
             synth -c artifactsBucketName=${{ secrets.S3_ARTIFACT_BUCKET }}
                   -c version=${{ steps.pull_request.outputs.number }}
+                  -c sendgridApiKey=${{ secrets.SENDGRID_API_KEY }}
           actions_comment: false
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
                    -c version=${{ steps.pull_request.outputs.number }}
                    -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
                    -c domainName=${{ secrets.DOMAIN_NAME }}
+                   -c sendgridApiKey=${{ secrets.SENDGRID_API_KEY }}
                    -c adminEmail=${{ secrets.ADMIN_EMAIL }}
           cdk_args: '--require-approval never'
           actions_comment: false

--- a/gfa-iac/.gitignore
+++ b/gfa-iac/.gitignore
@@ -1,4 +1,3 @@
-*.js
 !jest.config.js
 *.d.ts
 node_modules

--- a/gfa-iac/lib/function/gfa-function-invoke.ts
+++ b/gfa-iac/lib/function/gfa-function-invoke.ts
@@ -15,7 +15,7 @@ export class GfaFunctionWithInvokeTask extends Construct {
     constructor(scope: Construct, id: string, props: GfaFunctionWithInvokeTaskProps) {
         super(scope, id);
 
-        this.handler = new GfaFunction(scope, id, props).handler;
+        this.handler = new GfaFunction(scope, `${id}-function`, props).handler;
         this.task = new LambdaInvoke(scope, `invoke-${props.name}`, {
             lambdaFunction: this.handler,
             outputPath: props.outputPath,

--- a/gfa-iac/lib/gfa-notify-stack.ts
+++ b/gfa-iac/lib/gfa-notify-stack.ts
@@ -47,7 +47,7 @@ export class NotifyStack extends NestedStack {
         }).addAlarmAction(new SnsAction(props.alertTopic));
 
         const subscribe = new GfaFunction(this, 'subscribe', {
-            name: 'notify',
+            name: 'subscribe',
             environment: {
                 TODAY_TOPIC: arrivalToday.topicArn,
             }

--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -63,14 +63,14 @@ export class GbgFarligtAvfallStack extends Stack {
       ]
     });
 
-    // const sendgridApiKey = app.node.tryGetContext('sendgridApiKey');
-    // const hostedZoneId = app.node.tryGetContext('hostedZoneId');
-    // const domainName = app.node.tryGetContext('domainName');
-    // new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
-      // hostedZoneId,
-      // domainName,
-      // apiKey: sendgridApiKey,
-    // });
+    const sendgridApiKey = app.node.tryGetContext('sendgridApiKey');
+    const hostedZoneId = app.node.tryGetContext('hostedZoneId');
+    const domainName = app.node.tryGetContext('domainName');
+    new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
+      hostedZoneId,
+      domainName,
+      apiKey: sendgridApiKey,
+    });
 
     new CfnOutput(this, 'WebBucket', {
       value: webStack.webHostingBucketName,

--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -8,6 +8,7 @@ import { ApiStack } from './gfa-api-stack';
 import { WebStack } from './gfa-web-stack';
 import { NotifyStack } from './gfa-notify-stack';
 import { GfaFunction } from './function/gfa-function';
+import { SendGridDomainVerifier } from './sendgrid/domain-verifier';
 
 export class GbgFarligtAvfallStack extends Stack {
 
@@ -60,6 +61,14 @@ export class GbgFarligtAvfallStack extends Stack {
         },
         notifyStack.subscribeEndpoint,
       ]
+    });
+
+    const hostedZoneId = app.node.tryGetContext('hostedZoneId');
+    const domainName = app.node.tryGetContext('domainName');
+    new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
+      hostedZoneId,
+      domainName,
+      apiKey: 'some-key'
     });
 
     new CfnOutput(this, 'WebBucket', {

--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -63,14 +63,14 @@ export class GbgFarligtAvfallStack extends Stack {
       ]
     });
 
-    const sendgridApiKey = app.node.tryGetContext('sendgridApiKey');
-    const hostedZoneId = app.node.tryGetContext('hostedZoneId');
-    const domainName = app.node.tryGetContext('domainName');
-    new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
-      hostedZoneId,
-      domainName,
-      apiKey: sendgridApiKey,
-    });
+    // const sendgridApiKey = app.node.tryGetContext('sendgridApiKey');
+    // const hostedZoneId = app.node.tryGetContext('hostedZoneId');
+    // const domainName = app.node.tryGetContext('domainName');
+    // new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
+      // hostedZoneId,
+      // domainName,
+      // apiKey: sendgridApiKey,
+    // });
 
     new CfnOutput(this, 'WebBucket', {
       value: webStack.webHostingBucketName,

--- a/gfa-iac/lib/gfa-stack.ts
+++ b/gfa-iac/lib/gfa-stack.ts
@@ -63,12 +63,13 @@ export class GbgFarligtAvfallStack extends Stack {
       ]
     });
 
+    const sendgridApiKey = app.node.tryGetContext('sendgridApiKey');
     const hostedZoneId = app.node.tryGetContext('hostedZoneId');
     const domainName = app.node.tryGetContext('domainName');
     new SendGridDomainVerifier(this, 'gfa-sendgrid-verifier', {
       hostedZoneId,
       domainName,
-      apiKey: 'some-key'
+      apiKey: sendgridApiKey,
     });
 
     new CfnOutput(this, 'WebBucket', {

--- a/gfa-iac/lib/sendgrid/domain-verifier-lambda.js
+++ b/gfa-iac/lib/sendgrid/domain-verifier-lambda.js
@@ -1,0 +1,176 @@
+const https = require('https');
+const url = require('url');
+const AWS = require('aws-sdk')
+
+const baseUrl = 'https://api.sendgrid.com/v3';
+
+exports.handler = async function (event, context) {
+    const { ResourceProperties: properties, RequestType: requestType, PhysicalResourceId: physicalId } = event;
+    switch (requestType) {
+        case 'Create':
+            return handleCreate(properties.apiKey, properties.domain, properties.hostedZoneId);
+        case 'Update':
+            return handleUpdate(properties.apiKey, physicalId);
+        case 'Delete':
+            return handleDelete(properties.apiKey, physicalId);
+    }
+}
+
+const handleCreate = async (apiKey, domain, hostedZoneId) => {
+    const authenticationResponse = await createDomainAuthentication(apiKey, domain)
+        .catch(error => {
+            throw new Error('Failed to authenticate domain: ' + error);
+        })
+    const {id, dns} = authenticationResponse;
+    await addAuthenticationRecords(hostedZoneId, dns)
+        .catch(error => {
+            // Delete authentication in SendGrid?
+            throw new Error('Failed to add CNAME records to Route53: ' + error);
+        });
+    await retry(() => validateDomainAuthentication(apiKey, id), 'Failed to validate domain authentication')
+        .catch(error => {
+            throw new Error('Failed to validate domain authentication: ' + error);
+        });
+    return successfulCloudFormationResponse(id.toString(10), {});
+}
+
+const handleUpdate = (apiKey, id) => {
+    console.log('UPDATE event');
+    throw new Error('Failed to update :(');
+}
+
+const handleDelete = async (apiKey, id) => {
+    await deleteDomainAuthentication(apiKey, id)
+        .catch(error => {
+            throw new Error('Failed to delete domain authentication: ' + error);
+        })
+    return successfulCloudFormationResponse(id, {});
+}
+
+const successfulCloudFormationResponse = (physicalResourceId, responseData) => {
+    return {
+        PhysicalResourceId: physicalResourceId,
+        Data: responseData
+    };
+}
+
+const addAuthenticationRecords = (hostedZoneId, recordsToAdd) => {
+    const route53 = new AWS.Route53();
+    return route53.changeResourceRecordSets({
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+            Changes: Object.values(recordsToAdd).map(record => ({
+                Action: 'CREATE',
+                ResourceRecordSet: {
+                    Name: record.host,
+                    Type: record.type.toUpperCase(),
+                    TTL: 300,
+                    ResourceRecords: [{
+                        Value: record.data
+                    }]
+                }
+            }))
+        }
+    }).promise();
+}
+
+const getAuthenticatedDomains = (apiKey) => {
+    const uri = new url.URL(baseUrl + '/whitelabel/domains');
+    return makeRequest(uri, {
+        method: 'GET',
+        headers: {
+            Authorization: 'Bearer ' + apiKey
+        }
+    }).then(response => JSON.parse(response));
+}
+
+const createDomainAuthentication = (apiKey, domain) => {
+    const uri = new url.URL(baseUrl + '/whitelabel/domains');
+    return makeRequest(uri, {
+        method: 'POST',
+        headers: {
+            Authorization: 'Bearer ' + apiKey
+        }
+    }, JSON.stringify({
+        domain,
+    })).then(response => JSON.parse(response));
+}
+
+const validateDomainAuthentication = (apiKey, id) => {
+    const uri = new url.URL(baseUrl + `/whitelabel/domains/${id}/validate`);
+    return makeRequest(uri, {
+        method: 'POST',
+        headers: {
+            Authorization: 'Bearer ' + apiKey
+        }
+    }).then(response => {
+        response = JSON.parse(response)
+        if (!response.valid) {
+            throw new Error('Invalid domain authentication');
+        }
+        return response;
+    });
+}
+
+const deleteDomainAuthentication = (apiKey, id) => {
+    const uri = new url.URL(baseUrl + `/whitelabel/domains/${id}`);
+    return makeRequest(uri, {
+        method: 'DELETE',
+        headers: {
+            Authorization: 'Bearer ' + apiKey
+        }
+    });
+}
+
+const retry = async (fn, errorMessage, retryCount = 0, lastError = null) => {
+    try {
+        return await fn();
+    } catch (error) {
+        if (retryCount > 15) {
+            throw new Error(lastError);
+        }
+        if (errorMessage) {
+            console.warn(errorMessage);
+        }
+        const delayInMs = 2 ** retryCount * 10;
+        await delay(delayInMs);
+        return retry(fn, errorMessage, retryCount + 1, error);
+    }
+}
+
+const delay = ms =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+const makeRequest = (uri, options, data) => new Promise((resolve, reject) => {
+    if (!uri instanceof url.URL) {
+        throw new Error('url must be an instance of url.URL');
+    }
+    const fullPath = uri.pathname.concat(uri.search ? uri.search : '');
+    const req = https.request({
+        hostname: uri.hostname,
+        path: fullPath,
+        method: options.method,
+        headers: options.headers,
+        protocol: uri.protocol
+    }, (res) => {
+        res.setEncoding('utf8');
+        if (res.statusCode < 200 || res.statusCode > 299) {
+            res.on('data', chunk => {});
+            return reject(new Error("Bad status code: " + res.statusCode));
+        }
+        let responseBody = '';
+        res.on('data', chunk => {
+            responseBody += chunk;
+        });
+        res.on('end', () => {
+            return resolve(responseBody);
+        });
+    });
+    req.on('error', err => {
+        return reject(err);
+    });
+    if (data) {
+        req.write(data);
+    }
+    req.end();
+});

--- a/gfa-iac/lib/sendgrid/domain-verifier.ts
+++ b/gfa-iac/lib/sendgrid/domain-verifier.ts
@@ -10,7 +10,6 @@ export interface SendGridDomainVerifierProps {
     apiKey: string,
 }
 
-// https://baihuqian.github.io/2020-12-17-lambda-based-cdk-custom-resource-with-input-and-output/
 export class SendGridDomainVerifier extends Construct {
 
     constructor(scope: Construct, id: string, props: SendGridDomainVerifierProps) {
@@ -36,8 +35,7 @@ export class SendGridDomainVerifier extends Construct {
             onEventHandler: domainVerifier,
         });
 
-        const domain = 'myDomain';
-        const customResource = new CustomResource(this, `sendgrid-domain-verifier-${domain}`, {
+        new CustomResource(this, `sendgrid-domain-verifier-${props.domainName}`, {
             serviceToken: provider.serviceToken,
             properties: {
                 hostedZoneId: props.hostedZoneId,

--- a/gfa-iac/lib/sendgrid/domain-verifier.ts
+++ b/gfa-iac/lib/sendgrid/domain-verifier.ts
@@ -1,0 +1,36 @@
+import { Construct, CustomResource } from "@aws-cdk/core";
+import { Function, Runtime, Code } from '@aws-cdk/aws-lambda';
+import { Provider } from '@aws-cdk/custom-resources';
+
+export interface SendGridDomainVerifierProps {
+    hostedZoneId: string,
+    domainName: string,
+    apiKey: string,
+}
+
+// https://baihuqian.github.io/2020-12-17-lambda-based-cdk-custom-resource-with-input-and-output/
+export class SendGridDomainVerifier extends Construct {
+
+    constructor(scope: Construct, id: string, props: SendGridDomainVerifierProps) {
+        super(scope, id);
+
+        const domainVerifier = new Function(this, `sendgrid-domain-verifier-lambda`, {
+            runtime: Runtime.NODEJS_12_X,
+            code: Code.fromAsset('lib/sendgrid'),
+            handler: 'domain-verifier-lambda.handler',
+        });
+
+        const provider = new Provider(this, 'sendgrid-domain-verifier-provider', {
+            onEventHandler: domainVerifier,
+        });
+
+        const domain = 'myDomain';
+        const customResource = new CustomResource(this, `sendgrid-domain-verifier-${domain}`, {
+            serviceToken: provider.serviceToken,
+            properties: {
+                hostedZoneId: props.hostedZoneId,
+                domain: props.domainName
+            },
+        });
+    }
+}

--- a/gfa-iac/lib/sendgrid/domain-verifier.ts
+++ b/gfa-iac/lib/sendgrid/domain-verifier.ts
@@ -1,6 +1,8 @@
-import { Construct, CustomResource } from "@aws-cdk/core";
+import { Construct, CustomResource, Duration } from "@aws-cdk/core";
 import { Function, Runtime, Code } from '@aws-cdk/aws-lambda';
 import { Provider } from '@aws-cdk/custom-resources';
+import { Effect, PolicyStatement } from "@aws-cdk/aws-kms/node_modules/@aws-cdk/aws-iam";
+import { HostedZone } from '@aws-cdk/aws-route53';
 
 export interface SendGridDomainVerifierProps {
     hostedZoneId: string,
@@ -18,7 +20,17 @@ export class SendGridDomainVerifier extends Construct {
             runtime: Runtime.NODEJS_12_X,
             code: Code.fromAsset('lib/sendgrid'),
             handler: 'domain-verifier-lambda.handler',
+            timeout: Duration.minutes(6),
         });
+        const hostedZone = HostedZone.fromHostedZoneAttributes(this, 'temp-hostedzone', {
+            hostedZoneId: props.hostedZoneId,
+            zoneName: props.domainName,
+        });
+        domainVerifier.addToRolePolicy(new PolicyStatement({
+            effect: Effect.ALLOW,
+            resources: [hostedZone.hostedZoneArn],
+            actions: ['route53:ChangeResourceRecordSets']
+        }));
 
         const provider = new Provider(this, 'sendgrid-domain-verifier-provider', {
             onEventHandler: domainVerifier,
@@ -29,7 +41,8 @@ export class SendGridDomainVerifier extends Construct {
             serviceToken: provider.serviceToken,
             properties: {
                 hostedZoneId: props.hostedZoneId,
-                domain: props.domainName
+                domain: props.domainName,
+                apiKey: props.apiKey
             },
         });
     }

--- a/gfa-iac/package.json
+++ b/gfa-iac/package.json
@@ -30,6 +30,7 @@
     "@aws-cdk/aws-codedeploy": "1.67.0",
     "@aws-cdk/aws-codepipeline": "1.67.0",
     "@aws-cdk/aws-codepipeline-actions": "1.67.0",
+    "@aws-cdk/custom-resources": "1.67.0",
     "@aws-cdk/aws-dynamodb": "1.67.0",
     "@aws-cdk/aws-events": "1.67.0",
     "@aws-cdk/aws-events-targets": "1.67.0",


### PR DESCRIPTION
Add a new custom resource for performing domain authentication towards Sendgrid. The resource will:
 - On CREATE:
   - POST a new domain authentication to Sendgrid
   - Add CNAME records for authentication to hosted zone
   - Try to verify the domain authentication (this is done with a retry, since DNS propagation might take some time)
- On UPDATE:
   - If only apiKey has changed, do nothing
   - If hostedZoneId or domain has changed - Treat this the same way as a create event (this will return a new physical id for the resource, in essence telling CloudFormation to treat this as a new resource, and delete the old one)
- On DELETE:
  - Remove CNAME records from hosted zone
  - Delete domain authentication in Sendgrid