### PR TITLE
Setup pretty URL for web

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
                   -c version=${{ steps.pull_request.outputs.number }}
                   -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
                   -c domainName=${{ secrets.DOMAIN_NAME }}
-                   -c adminEmail=${{ secrets.ADMIN_EMAIL }}
+                  -c adminEmail=${{ secrets.ADMIN_EMAIL }}
                   -c sendgridApiKey=${{ secrets.SENDGRID_API_KEY }}
           actions_comment: false
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
           cdk_subcommand: >
             synth -c artifactsBucketName=${{ secrets.S3_ARTIFACT_BUCKET }}
                   -c version=${{ steps.pull_request.outputs.number }}
+                  -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
+                  -c domainName=${{ secrets.DOMAIN_NAME }}
+                   -c adminEmail=${{ secrets.ADMIN_EMAIL }}
                   -c sendgridApiKey=${{ secrets.SENDGRID_API_KEY }}
           actions_comment: false
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,19 @@ jobs:
           PR_NUMBER=$(curl -s -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/Dunklas/gbg-farligt-avfall/commits/$GITHUB_SHA/pulls | jq -r '.[0].number')
           echo "::set-output name=number::$PR_NUMBER"
         id: pull_request
-      
-      - name: Deploy to AWS
+     
+      - name: Deploy web certificate
+        uses: youyo/aws-cdk-github-actions@v1
+        with:
+          working_dir: 'gfa-iac'
+          cdk_subcommand: >
+            deploy -c hostedZoneId=${{ secrets.HOSTED_ZONE_ID }}
+                   -c domainName=${{ secrets.DOMAIN_NAME }}
+                   GbgFarligtAvfallWebCertStack
+          cdk_args: '--require-approval never'
+          actions_comment: false
+
+      - name: Deploy main stack
         uses: youyo/aws-cdk-github-actions@v1
         with:
           working_dir: 'gfa-iac'
@@ -37,6 +48,7 @@ jobs:
                    -c domainName=${{ secrets.DOMAIN_NAME }}
                    -c sendgridApiKey=${{ secrets.SENDGRID_API_KEY }}
                    -c adminEmail=${{ secrets.ADMIN_EMAIL }}
+                   GbgFarligtAvfallStack
           cdk_args: '--require-approval never'
           actions_comment: false
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ End goal is to have subscriptions, and send notifications some time before the t
    - AWS_SECRET_ACCESS_KEY
    - AWS_REGION
    - S3_ARTIFACT_BUCKET 
+   - DOMAIN_NAME
+   - HOSTED_ZONE_ID
+   - SENDGRID_API_KEY
    - ADMIN_EMAIL (optional)
-   - DOMAIN_NAME (optional)
-   - HOSTED_ZONE_ID (optional)
 
 ## First deploy
 The first time you're deploying this stack you'll need to run the following command:
@@ -27,10 +28,3 @@ Launch frontend with 'real' API:
  - Add name of the folder created above to the build step of `.github/workflows/build.yml`:
    - `executables="get-stops save-events save-stops scraper notify subscribe NEW-FOLDER"`
  - Add CDK resource for the new lambda to a suitable stack in `gfa-iac/lib`
-
- ## Limitations
-For sending notifications, AWS SNS is used. Currently a single topic is used, and to only notify relevant subscribers is handled via subscription filters.
-Since subscription filters are used, it's quite hard to update an existing subscription. It's possible to do via the AWS Console, but it's hard to design an API for it.
-Additionally, AWS SNS have very limited possibilites for changing the e-mail template.
-
-If this were to be used 'for real', I think AWS SNS would need to be replaced with something better suited for sending (transactional?) emails. Preferably with double opt-in, per location that the user subscribes to.

--- a/gfa-iac/bin/gfa-main.ts
+++ b/gfa-iac/bin/gfa-main.ts
@@ -1,6 +1,16 @@
 #!/usr/bin/env node
 import { App } from '@aws-cdk/core';
 import { GbgFarligtAvfallStack } from '../lib/main-stack';
+import { WebCertStack } from '../lib/web-cert-stack';
 
 const app = new App();
-const gfaStack = new GbgFarligtAvfallStack(app, 'GbgFarligtAvfallStack');
+
+// To use an ACM certificate for CloudFront, it must exist in us-east-1
+// To enable usage in other regions, this stack puts the certificateArn in Parameter Store
+new WebCertStack(app, 'GbgFarligtAvfallWebCertStack', {
+    env: {
+        region: 'us-east-1',
+    },
+});
+
+new GbgFarligtAvfallStack(app, 'GbgFarligtAvfallStack');

--- a/gfa-iac/lib/web-cert-stack.ts
+++ b/gfa-iac/lib/web-cert-stack.ts
@@ -1,0 +1,30 @@
+import { Construct, Stack, StackProps } from "@aws-cdk/core";
+import { Certificate } from '@aws-cdk/aws-certificatemanager';
+import { CertificateValidation } from '@aws-cdk/aws-certificatemanager';
+import { HostedZone } from '@aws-cdk/aws-route53';
+import { StringParameter } from "@aws-cdk/aws-ssm";
+
+export class WebCertStack extends Stack {
+    constructor(scope: Construct, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        const domainName = scope.node.tryGetContext('domainName');
+        const hostedZoneId = scope.node.tryGetContext('hostedZoneId');
+        const webDomainName = `gfa.${domainName}`;
+
+        const hostedZone = HostedZone.fromHostedZoneAttributes(this, 'e-hostedzone', {
+            hostedZoneId: hostedZoneId,
+            zoneName: domainName,
+        });
+
+        const webCert = new Certificate(this, 'web-certificate', {
+            domainName: webDomainName,
+            validation: CertificateValidation.fromDns(hostedZone),
+        });
+
+        new StringParameter(this, 'web-certificate-parameter', {
+            parameterName: 'gfa-web-certificate',
+            stringValue: webCert.certificateArn
+        });
+    }
+}

--- a/gfa-iac/package.json
+++ b/gfa-iac/package.json
@@ -42,6 +42,7 @@
     "@aws-cdk/aws-secretsmanager": "1.67.0",
     "@aws-cdk/aws-sns": "1.67.0",
     "@aws-cdk/aws-sns-subscriptions": "1.67.0",
+    "@aws-cdk/aws-ssm": "1.67.0",
     "@aws-cdk/aws-stepfunctions": "1.67.0",
     "@aws-cdk/aws-stepfunctions-tasks": "1.67.0",
     "@aws-cdk/core": "1.67.0",


### PR DESCRIPTION
To do this, I had to create an ACM certificate in us-east-1 for the new domain. This is due to that CloudFront require ACM certificates to exist in us-east-1.
In order to accomplish this, I introduced a new stack separate from the 'main stack,', which is deployed to us-east-1.
The ARN of the ACM certificate is put into ParameterStore, and then obtained in the main stack to configure CloudFront.
