### PR TITLE
Resolve HTTP 500 from new API gateway v2

### DIFF
--- a/gfa-backend/src/add-subscription/main.rs
+++ b/gfa-backend/src/add-subscription/main.rs
@@ -105,7 +105,7 @@ fn create_response(status_code: i64, body: String) -> ApiGatewayV2httpResponse {
         headers: HashMap::new(),
         multi_value_headers: HashMap::new(),
         body: Some(body),
-        is_base64_encoded: None,
+        is_base64_encoded: Some(false),
         cookies: Vec::new()
     }
 }

--- a/gfa-backend/src/get-stops/main.rs
+++ b/gfa-backend/src/get-stops/main.rs
@@ -79,7 +79,7 @@ fn create_response(body: String) -> ApiGatewayV2httpResponse {
         headers: HashMap::new(),
         multi_value_headers: HashMap::new(),
         body: Some(body),
-        is_base64_encoded: None,
+        is_base64_encoded: Some(false),
         cookies: Vec::new()
     }
 }

--- a/gfa-backend/src/verify-subscription/main.rs
+++ b/gfa-backend/src/verify-subscription/main.rs
@@ -63,7 +63,7 @@ fn create_response(status_code: i64, body: String) -> ApiGatewayV2httpResponse {
         headers: HashMap::new(),
         multi_value_headers: HashMap::new(),
         body: Some(body),
-        is_base64_encoded: None,
+        is_base64_encoded: Some(false),
         cookies: Vec::new()
     }
 }


### PR DESCRIPTION
According to logs lambda response contains wrong type for field `isBase64Encoded`. Let's try to set it to false!