### PR TITLE
Pipeline fixes

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -46,8 +46,8 @@ jobs:
           PREVIOUS_VERSION=$((VERSION-1))
           for executable in ${{ env.EXECUTABLES }};
           do
-            aws s3 sync s3://${{ secrets.S3_ARTIFACT_BUCKET }}/gfa-$executable-$PREVIOUS_VERSION \
-                        s3://${{ secrets.S3_ARTIFACT_BUCKET }}/gfa-$executable-$VERSION
+            aws s3 cp s3://${{ secrets.S3_ARTIFACT_BUCKET }}/gfa-$executable-$PREVIOUS_VERSION \
+                      s3://${{ secrets.S3_ARTIFACT_BUCKET }}/gfa-$executable-$VERSION
           done
 
   lint-backend:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,3 +102,20 @@ jobs:
 
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id ${{ steps.web_hosting.outputs.dist_id }} --paths "/*" 
+
+  test-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release cache
+        uses: actions/cache@v2
+        with:
+          path: gfa-backend/target
+          key: ${{ runner.os }}-build-release-cache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-release-cache-
+      - name: Unit tests
+        run: (cd gfa-backend && cargo test --release)
+
+


### PR DESCRIPTION
 - Use `s3 cp` instead of `s3 sync`. Seems like no action is made by the SDK otherwise (maybe because both source and target is in same bucket, but I'm not sure)
 - Add a backend test step to deploy pipeline
   - I hope this will make the cached target folder available on the master branch, which should speed up any build quite a lot
   - If only caching on pull request I think the cached target folder will be related to the feature branch, and will not apply for any other new feature branch