### PR TITLE
Sort list of stops, and remove any duplicates

### DIFF
--- a/gfa-backend/src/common/pickup_stop.rs
+++ b/gfa-backend/src/common/pickup_stop.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use serde::{Serialize, Deserialize};
 
-#[derive(fmt::Debug, Serialize, Deserialize)]
+#[derive(fmt::Debug, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct PickUpStop {
     pub location_id: String,
     pub street: String,
@@ -27,6 +27,7 @@ impl PartialEq for PickUpStop {
         self.location_id == other.location_id
     }
 }
+impl Eq for PickUpStop {}
 
 impl PickUpStop {
     pub fn new(location_id: String, street: String, district: String, description: Option<String>) -> Self {

--- a/gfa-backend/src/common/stops_repo.rs
+++ b/gfa-backend/src/common/stops_repo.rs
@@ -21,7 +21,7 @@ pub async fn get_all_stops(table: &str, region: &Region, location_index: &str) -
         Some(items) => items,
         None => return Err(Box::new(MalformedDynamoDbResponse))
     };
-    Ok(items.iter()
+    let mut stops = items.iter()
         .map(|item| item_to_stop(item))
         .filter_map(|optional_stop| {
             if optional_stop.is_none() {
@@ -30,8 +30,10 @@ pub async fn get_all_stops(table: &str, region: &Region, location_index: &str) -
             }
             Some(optional_stop.unwrap())
         })
-        .collect()
-    )
+        .collect::<Vec<PickUpStop>>();
+    stops.sort();
+    stops.dedup();
+    Ok(stops)
 }
 
 fn item_to_stop(item: &HashMap<String, AttributeValue>) -> Option<PickUpStop> {


### PR DESCRIPTION
My initial hope was that I wouldn't have a need to remove duplicates programatically. Basically because with the byLocationId index I use location_id as hash key, so my thought was that only unique items would exist. Turns out however that DynamoDb in some way includes the range key of the base index anyway, and still list multiple items with the same hash key
